### PR TITLE
Fix offline_as_scope option

### DIFF
--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ type AppConfig struct {
 			RootCA string `yaml:"root_ca"`
 		} `yaml:"issuer"`
 		ExtraScopes    []string `yaml:"extra_scopes"`
-		OfflineAsScope bool     `yaml:"offline_as_scope"`
+		OfflineAsScope *bool    `yaml:"offline_as_scope"`
 		CrossClients   []string `yaml:"cross_clients"`
 	} `yaml:"oidc"`
 	Tls struct {

--- a/templates.go
+++ b/templates.go
@@ -80,11 +80,13 @@ var tokenTmpl = template.Must(template.New("token.html").Parse(`<html>
   user:
     auth-provider:
       config:
-        client-id: {{ .ClientID }}
-        client-secret: {{ .ClientSecret }}
-        id-token: {{ .IDToken }}
         idp-issuer-url: {{ .Claims.iss }}
+        client-id: {{ .ClientID }}
+        id-token: {{ .IDToken }}
+{{- if ne .RefreshToken "" }}
+        client-secret: {{ .ClientSecret }}
         refresh-token: {{ .RefreshToken }}
+{{- end }}
       name: oidc</code></pre>
                </div>
             </li>


### PR DESCRIPTION
The `offline_as_scope` config option doesn't currently do anything because the variable gets overridden by the supported scopes from the OIDC issuer (or just set to true if the issuer doesn't advertise the supported scopes). This PR:

- Changes the `OfflineAsScope` config option to a `*bool` so that we can differentiate between intentionally set in the config file and omitted (if there's a better approach in Go, I'd be interested in knowing)
- Removes a previously unreachable condition based on the `OfflineAsScope` option
- Updates the template to hide the `client-secret` and `refresh-token` options in the kubeconfig file (`idp-issuer-url` and `client-secret` are both still required without a refresh token)