### PR TITLE
Show a kubectl based version of configuration update

### DIFF
--- a/templates/token.html
+++ b/templates/token.html
@@ -35,6 +35,22 @@
       name: oidc</code></pre>
           </div>
         </li>
+        <li>
+          <label>or execute this in your shell</label>
+          <div class="code-box-copy">
+            <button class="code-box-copy__btn" title=
+            "Copy" type="button" data-clipboard-target="#kubectl">
+            </button>
+            <pre><code class="language-yaml" id=
+              "kubectl">kubectl config set-credentials {{ .UsernameClaim }} \
+    --auth-provider oidc \
+    --auth-provider-arg idp-issuer-url={{ .Claims.iss }} \
+    --auth-provider-arg client-id={{ .ClientID }} \
+    --auth-provider-arg id-token={{ .IDToken }} \
+    --auth-provider-arg client-secret={{ .ClientSecret }} \
+    --auth-provider-arg refresh-token={{ .RefreshToken }}</code></pre>
+          </div>
+        </li>
         <li><label>Return to login page</label> <input type=
         "submit" value="Home"></li>
       </ul>


### PR DESCRIPTION
For convenience, show the kubectl command that you can execute to modify your configuration.

Beware that these informations will be stored in your shell history. In general, both your history and your kubeconfig are in your home directory and have the same permissions, so it shouldn't be a problem.