### PR TITLE
Support using a specific LoadBalancer IP

### DIFF
--- a/helm/loginapp/templates/service.yaml
+++ b/helm/loginapp/templates/service.yaml
@@ -6,6 +6,9 @@ metadata:
     {{- include "loginapp.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+{{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+{{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/helm/loginapp/values.yaml
+++ b/helm/loginapp/values.yaml
@@ -36,6 +36,7 @@ service:
   port: 5555
 
   nodePort:
+  loadBalancerIP:
 
 ingress:
   enabled: false


### PR DESCRIPTION
This will allow you to set a specific LoadBalancer IP.

It is useful in cases where static IPs are required (e.g. on-prem clusters).

It's been tested internally but please let me know if you need any help verifying.

Thanks!