### PR TITLE
Google compatibility, split auth code opts and kubeconfig opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,16 +101,26 @@ oidc:
     # Default: false
     insecureSkipVerify: false
 
+  # List of scopes to request.
+  # Updating this parameter will override existing scopes.
+  # Default:[openid,profile,email,groups]
+  scopes: []
+
   # OIDC extra configuration
   extra:
-    # OIDC Scopes in addition to
+    # [DEPREACTED] OIDC Scopes in addition to
     # "openid", "profile", "email", "groups"
+    #
+    # Use oidc.scopes instead
+    #
     # default: []
     scopes: []
 
     # Extra auth code options
-    # Some extra auth code options are required for ADFS compatibility (ex: resource).
-    # See: https://docs.microsoft.com/fr-fr/windows-server/identity/ad-fs/overview/ad-fs-scenarios-for-developers
+    # Some extra auth code options are required for:
+    # * ADFS compatibility (ex: resource, https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/overview/ad-fs-openid-connect-oauth-flows-scenarios)
+    # * Google OIDC compatibility (ex: https://developers.google.com/identity/protocols/oauth2/openid-connect#refresh-tokens)
+    # See: 
     # default: {}
     authCodeOpts:
       resource: XXXXX
@@ -154,6 +164,21 @@ web:
     # If not set, use a format like 'defaultClusterName'/'usernameClaim'
     # Default: ""
     defaultContext: altcontextname
+    # Extra key/value pairs to add to kubeconfig output.
+    # Key/value pairs are added under `user.auth-provider.config`
+    # dictionnary into the kubeconfig.
+    # Ex:
+    # extraOpts:
+    #   mykey1: value1
+    #
+    # Kubeconfig Output:
+    # - name: user.name@example.org
+    #     auth-provider:
+    #       config:
+    #         mykey1: value1
+    #         client-id: loginapp
+    #         [...]
+    extraOpts: {}
 
 # Metrics configuration
 metrics:

--- a/docs/adfs-compatibility.md
+++ b/docs/adfs-compatibility.md
@@ -1,0 +1,43 @@
+# ADFS compatibility
+
+## Resource URL
+
+ADFS accepts a resource URL as a part of authentication request flow, it is used to identify your Web API.
+
+To add resource URL on the request, use the OIDC extra auth code options config :
+
+```yaml
+config:
+  oidc:
+    extra:
+      authCodeOpts:
+        resource: xxxxxx
+```
+
+
+If you require the resource URL to be included in Kubeconfig (ex: for refresh tokens), update the Kubeconfig configuration part:
+
+```yaml
+config:
+  web:
+    kubeconfig:
+      extraOpts:
+        resource: xxxxxx
+```
+
+This will automatically add the extra options to the generated Kubeconfig and kubectl command:
+
+```yaml
+- name: admin@example.com
+  user:
+    auth-provider:
+      config:
+        resource: xxxxx         # added here
+        client-id: loginapp
+        [...]
+```
+
+
+For more informations:
+* ADFS: https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/overview/ad-fs-openid-connect-oauth-flows-scenarios
+* Issue: https://github.com/fydrah/loginapp/issues/16

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -7,6 +7,7 @@ Several identity providers exist:
 - [Dex](https://github.com/dexidp/dex/)
 - [Keycloak](https://www.keycloak.org/)
 - [Microsoft ADFS](https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/development/ad-fs-openid-connect-oauth-concepts)
+- [Google](https://developers.google.com/identity/protocols/oauth2/openid-connect)
 - ...
 
 
@@ -213,6 +214,11 @@ Here are the required configuration for Loginapp:
 - `config.clientRedirectURL`: this value depends on the deployment type you use. Must end with `/callback`
 - `config.issuerURL`: see [required configuration from IdP](#Required-configuration-from-IdP)
 - `config.issuerRootCA` (or `config.issuerInsecureSkipVerify` for testing)
+
+### (optional) Specific IdP configuration
+
+* [ADFS](adfs-compatibility.md)
+* [Google](google-compatibility.md)
 
 ### Configuration overwrite 
 

--- a/docs/google-compatibility.md
+++ b/docs/google-compatibility.md
@@ -1,0 +1,24 @@
+# Google compatibility
+
+## Refresh token
+
+Google openid-connect API supports refresh token, but not if requested as a scope.
+
+You must configure an extra option in request. To do so, add this to Loginapp configuration file:
+
+```yaml
+config:
+  oidc:
+    extra:
+      authCodeOpts:
+        access_type: offline
+        prompt: consent
+```
+
+
+These options will be added to the authentication request.
+
+
+For more informations:
+* Google OpenID documentation: https://developers.google.com/identity/protocols/oauth2/openid-connect
+* Issue: https://github.com/fydrah/loginapp/issues/32

--- a/pkg/config/app.go
+++ b/pkg/config/app.go
@@ -148,6 +148,7 @@ type WebKubeconfig struct {
 	DefaultCluster   string
 	DefaultNamespace string
 	DefaultContext   string
+	ExtraOpts        map[string]string
 }
 
 // AddFlags init web kubeconfig flags
@@ -155,4 +156,5 @@ func (wk *WebKubeconfig) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().String("web-kubeconfig-defaultcluster", "", "Default cluster name to use for full kubeconfig output")
 	cmd.Flags().String("web-kubeconfig-defaultnamespace", "default", "Default namespace to use for full kubeconfig output")
 	cmd.Flags().String("web-kubeconfig-defaultcontext", "", "Default context to use for full kubeconfig output. Use the following format by default: 'defaultcluster'/'usernameclaim'")
+	cmd.Flags().String("web-kubeconfig-extraopts", "", "Extra key/value pairs to add to kubeconfig output. Key/value pairs are added under `user.auth-provider.config` dictionnary into the kubeconfig")
 }

--- a/web/templates/token.html
+++ b/web/templates/token.html
@@ -48,7 +48,7 @@
             </button>
             <pre><code id="kubectl-code">kubectl config set-credentials {{ .UsernameClaim }} \
     --auth-provider oidc \
-{{- range $k,$v := .AppConfig.OIDC.Extra.AuthCodeOpts }}
+{{- range $k,$v := .AppConfig.Web.Kubeconfig.ExtraOpts }}
     --auth-provider-arg {{ $k }}={{ $v }} \
 {{- end }}
     --auth-provider-arg idp-issuer-url={{ .Claims.iss }} \
@@ -125,7 +125,7 @@ users:
   user:
     auth-provider:
       config:
-{{- range $k,$v := .AppConfig.OIDC.Extra.AuthCodeOpts }}
+{{- range $k,$v := .AppConfig.Web.Kubeconfig.ExtraOpts }}
         {{ $k }}: "{{ $v }}"
 {{- end }}
         idp-issuer-url: {{ .Claims.iss }}


### PR DESCRIPTION
In order to ensure google compat for refresh tokens, users must include
an extra auth code option to the authentication request.

This fixes 2 minor issues:
* Split auth code opts and kubeconfig extra opts: auth code options are
  not required in kubeconfig. To achieve this, we added a the option
  ``web.kubeconfig.extraOpts``
* Add documentation for ADFS & Google compat, this will help users to
  configure loginapp properly according to their IdP.

Fixes #32