### PR TITLE
OAuth2config must use prepared scopes and not config scopes

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -48,7 +48,7 @@ func (c *Client) OAuth2Config() *oauth2.Config {
 		ClientSecret: c.Config.Client.Secret,
 		RedirectURL:  c.Config.Client.RedirectURL,
 		Endpoint:     c.Provider.Endpoint(),
-		Scopes:       c.Config.Scopes,
+		Scopes:       c.Scopes,
 	}
 }
 


### PR DESCRIPTION
During the v3.2.1, we added the ability to override hardcoded scopes
(https://github.com/fydrah/loginapp/commit/bd70f3aeab1fa53089790603b47c1244ff249ed9).
But we missed that the OAuth2config should not use the scopes provided from config, but
instead the prepared scopes (to include the generated "offline_access" scope for example).

Fix #41