### PR TITLE
-- adjustments to run tests on macos

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,38 +1,40 @@
-apiVersion: skaffold/v2beta25
+apiVersion: skaffold/v3
 kind: Config
 metadata:
   name: loginapp
 build: {}
 deploy: {}
 profiles:
-- name: dex
-  deploy:
-    kubectl:
-      manifests:
-      - test/kubernetes/generated/dex-certs.yaml
-    helm:
-      releases:
-        - name: dex
-          namespace: kube-system
-          repo: https://charts.dexidp.io
-          remoteChart: dex
-          version: 0.6.3
-          valuesFiles:
-            - test/helm/generated/dex-overrides.yaml
-- name: helm
-  build:
-    artifacts:
-    - image: quay.io/fydrah/loginapp
-  deploy:
-    kubectl:
-      manifests:
-      - test/kubernetes/generated/dex-certs.yaml
-    helm:
-      releases:
-        - name: loginapphelm
-          chartPath: helm/loginapp
-          namespace: kube-system
-          setValues:
-            image: quay.io/fydrah/loginapp
-          valuesFiles:
-            - test/helm/generated/overrides.yaml
+  - name: dex
+    manifests:
+      rawYaml:
+        - "test/kubernetes/generated/dex-certs.yaml"
+    deploy:
+      kubectl: {}
+      helm:
+        releases:
+          - name: dex
+            namespace: kube-system
+            repo: https://charts.dexidp.io
+            remoteChart: dex
+            version: 0.6.3
+            valuesFiles:
+              - test/helm/generated/dex-overrides.yaml
+  - name: helm
+    build:
+      artifacts:
+      - image: quay.io/fydrah/loginapp
+    manifests:
+      rawYaml:
+        - test/kubernetes/generated/dex-certs.yaml
+    deploy:
+      kubectl: {}
+      helm:
+        releases:
+          - name: loginapphelm
+            chartPath: helm/loginapp
+            namespace: kube-system
+            setValues:
+              image: quay.io/fydrah/loginapp
+            valuesFiles:
+              - test/helm/generated/overrides.yaml

--- a/test/kubernetes/kind-cluster.yaml
+++ b/test/kubernetes/kind-cluster.yaml
@@ -1,5 +1,0 @@
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-nodes:
-- role: control-plane
-  image: kindest/node:v1.22.2

--- a/test/kubernetes/kindup.sh
+++ b/test/kubernetes/kindup.sh
@@ -1,5 +1,25 @@
 #!/bin/bash
 
 CURR_DIR=$(dirname $0)
+if [[ $OSTYPE == 'darwin'* ]]; then
+  cat << EOF > ${CURR_DIR}/generated/kind-cluster.yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  image: kindest/node:v1.22.2
+  extraPortMappings:
+    - containerPort: 32000
+      hostPort: 32000
+EOF
+else
+  cat << EOF > ${CURR_DIR}/generated/kind-cluster.yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  image: kindest/node:v1.22.2
+EOF
+fi
 
-kind create cluster --name=loginapp --config=${CURR_DIR}/kind-cluster.yaml
+kind create cluster --name=loginapp --config=${CURR_DIR}/generated/kind-cluster.yaml


### PR DESCRIPTION
MacOS has some differences in commands and the way kind is implemented, therefore current test does not work for MacOS environments. This PR is a try to make test env to work on mac:
1. Update skaffold yaml to support latest skaffold binary (v3)
2. genconfig.sh uses base64 command with "-w0" argument which is not supported on mac. 
3. genconfig.sh uses IP address of a kind docker container. MacOS does not support this kind of connectivity and the only option is to use localhost.
4. genconfig.sh added escaping for dollar sign in Dex staticpassword hash field.
5. kindup.sh generates kind.yaml with "extraPortMappings" for MacOS environments to overcome its limitation described in item 3.
